### PR TITLE
Remove legacy deps system

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,2 +1,0 @@
-python3 -m build
-python3 -m twine upload --repository pypi dist/*

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,0 @@
-setuptools
-twine
-isort
-build

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,0 @@
-fastapi
-PyNaCl
-uvicorn
-aiohttp
-python-dateutil
-python-multipart


### PR DESCRIPTION
Removes the legacy dependencies system (requirements.txt and dev-requirements.txt) as both of these things are now defined in pyproject.toml (and installing them from it is supported by pip too).

Also removes the old build system script as this is wholly replaced by Poetry.